### PR TITLE
Municipality and period in the same query, support for regions and municipality groups

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,10 +27,10 @@ Example usage
     'municipality': towns[:5],
   })
 
-  # ...or by area_group
-  areas = [x.value for x in dataset.dimensions['area_group'].allowed_values]
+  # ...or by municipality_groups
+  groups = [x.value for x in dataset.dimensions['municipality_groups'].allowed_values]
   data = dataset.fetch({
-    'area_group': areas[:5],
+    'municipality_groups': groups[:5],
   })
 
 
@@ -38,7 +38,7 @@ Example usage
   data = dataset.fetch({
     'period': [2016, 2015],
     'municipality': towns[:5],
-    'area_group': areas[:5],
+    'municipality_groups': groups[:5],
   })
 
   # And then do something with the results.

--- a/README.rst
+++ b/README.rst
@@ -27,10 +27,18 @@ Example usage
     'municipality': towns[:5],
   })
 
-  # ... or by both
+  # ...or by area_group
+  areas = [x.value for x in dataset.dimensions['area_group'].allowed_values]
+  data = dataset.fetch({
+    'area_group': areas[:5],
+  })
+
+
+  # ... or by all three
   data = dataset.fetch({
     'period': [2016, 2015],
     'municipality': towns[:5],
+    'area_group': areas[:5],
   })
 
   # And then do something with the results.

--- a/kolada/KoladaScraper.py
+++ b/kolada/KoladaScraper.py
@@ -73,7 +73,7 @@ class KoladaScraper(BaseScraper):
 
         if "municipality" in query:
             next_url += "/municipality/{}".format(",".join(query["municipality"]))
-        elif "period" in query:
+        if "period" in query:
             next_url += "/year/{}".format(",".join(query["period"]))
 
         while next_url:

--- a/kolada/KoladaScraper.py
+++ b/kolada/KoladaScraper.py
@@ -75,7 +75,7 @@ class KoladaScraper(BaseScraper):
 
     def _fetch_allowed_values(self, dimension):
         """Yield the allowed values for <dimension>."""
-        if dimension.id in 'municipality':
+        if dimension.id == 'municipality':
             municipalities = self._get_allowed_municipalities(
                 dimension.dataset.blob['municipality_type']
             )

--- a/kolada/KoladaScraper.py
+++ b/kolada/KoladaScraper.py
@@ -1,5 +1,5 @@
 # encoding: utf-8
-import math
+import math, re
 from copy import deepcopy
 
 from statscraper import BaseScraper, Dataset, Dimension, Result, DimensionValue
@@ -9,10 +9,16 @@ import requests
 class KoladaScraper(BaseScraper):
     """Sample scraper for statscraper boilerplate."""
 
+    @BaseScraper.on('init')
+    def _init(self):
+        """Inits variables for class"""
+        self.base_url = 'http://api.kolada.se/v2/'
+        self.areas = None
+        self.areaGroups = None
+
     def _fetch_itemslist(self, item):
         """Yield a collection or dataset at
         the current cursor position."""
-        self.base_url = 'http://api.kolada.se/v2/'
         r = requests.get(self.base_url + '/kpi')
         data = r.json()
         for d in data['values']:
@@ -20,26 +26,72 @@ class KoladaScraper(BaseScraper):
 
     def _fetch_dimensions(self, dataset):
         """Yield the available dimensions in <dataset>."""
+        yield Dimension('area_group', label='area group')
         yield Dimension('municipality', label='municipality')
         yield Dimension('kpi', label='indicator')
         yield Dimension('kpi_label', label='indicator name')
         yield Dimension('gender', label='gender')
         yield Dimension('period', label='period')
         yield Dimension('status', label='status')
+    
+    def _getAllowedAreas(self, type):
+        """Caches areas and returns them by type (`K`|`L`)"""
+        if self.areas == None:
+            self.areas = {
+                'K': [],
+                'L': []
+            }
+            data = requests.get(self.base_url + '/municipality').json()
+            for row in data['values']:
+                r = (row['id'], row['title'])
+                if row['type'] in ('K','L'):
+                    self.areas[row['type']].append(r)
+        if type in self.areas:
+            return self.areas[type]
+        return []
+    
+    def _getAllowedAreaGroups(self, type):
+        """Caches area groups and returns them by type (`K`|`L`)"""
+        if self.areaGroups == None:
+            self.areaGroups = {
+                'K': [],
+                'L': []
+            }
+
+            municipalityReg = re.compile(r'[Kk]ommuner')
+            regionalReg = re.compile(r'[Ll]andsting')
+
+            data = requests.get(self.base_url + '/municipality_groups').json()
+            for row in data['values']:
+                r = (row['id'], row['title'])
+                if municipalityReg.search(row['title']):
+                    self.areaGroups['K'].append(r)
+                elif regionalReg.search(row['title']):
+                    self.areaGroups['L'].append(r)
+        if type in self.areaGroups:
+            return self.areaGroups[type]
+        return []
+
 
     def _fetch_allowed_values(self, dimension):
         """Yield the allowed values for <dimension>."""
-        if dimension.dataset.blob['municipality_type'] in ('K', 'L'):
-            data = requests.get(self.base_url + '/municipality').json()
-            regions = []
-            for row in data['values']:
-                if row['type'] == dimension.dataset.blob['municipality_type']:
-                    regions.append((row['id'], row['title']))
+        if dimension.id in 'municipality':
+            areas = self._getAllowedAreas(dimension.dataset.blob['municipality_type'])
 
-            for r_id, r_name in regions:
-                yield DimensionValue(r_id,
+            for a_id, a_name in areas:
+                yield DimensionValue(a_id,
                                     dimension,
-                                    label=r_name)
+                                    label=a_name)
+        elif dimension.id == 'area_group':
+            areas = self._getAllowedAreaGroups(dimension.dataset.blob['municipality_type'])
+
+            for a_id, a_name in areas:
+                yield DimensionValue(a_id,
+                                    dimension,
+                                    label=a_name)
+
+
+
 
     def _fetch_data(self, dataset, query):
         """Make query for actual data.
@@ -53,14 +105,16 @@ class KoladaScraper(BaseScraper):
             {"period": 2016 }
         """
         
-        if type(query) is not dict:
+        # Make query a dict if isn't
+        if isinstance(query, dict) == False:
             query = {}
-        
-        #
-        if "municipality" not in query and "period" not in query:
-            query = {
-                "municipality": [x.value for x in dataset.dimensions["municipality"].allowed_values]
-            }
+
+        # If nothing is set, default to all allowed municipalities
+        queryable_dims = ['municipality', 'period', 'area_group']
+        if all([x not in query for x in queryable_dims]):
+            query['municipality'] = []
+            for x in dataset.dimensions['municipality'].allowed_values:
+                query['municipality'].append(x.value)
 
         # Listify queried values (to allow single values in query, like {"year": 2016})
         for key, values in query.items():
@@ -70,27 +124,38 @@ class KoladaScraper(BaseScraper):
             query[key] = [str(x) for x in query[key]]
 
         # Validate query
-        queryable_dims = ["municipality", "period"]
         for dim in query.keys():
             if dim not in queryable_dims:
                 raise Exception("You cannot query on dimension '{}'".format(dim))
-            #TODO: Make sure tha values passed in query are allowed.
+            # Check if the values are allowed
+            if dim in ('municipality', 'area_group'):
+                allowed = [x.value for x in dataset.dimensions[dim].allowed_values]
+                for dimVal in query[dim]:
+                    if dimVal not in allowed:
+                        raise Exception("You cannot query on dimension '{}' with '{}'".format(dim, dimVal))
 
         # base url for query
         next_url = '{}data/kpi/{}'.format(self.base_url, dataset.id)
 
-        if "municipality" in query:
-            next_url += "/municipality/{}".format(",".join(query["municipality"]))
-        if "period" in query:
-            next_url += "/year/{}".format(",".join(query["period"]))
+        # Merge `municipality` and `area_group`
+        municipalities = []
+        if 'municipality' in query:
+            municipalities = municipalities + query['municipality']
+        if 'area_group' in query:
+            municipalities = municipalities + query['area_group']
+
+        if len(municipalities) > 0:
+            next_url += '/municipality/{}'.format(','.join(municipalities))
+        if 'period' in query:
+            next_url += '/year/{}'.format(','.join(query['period']))
 
         while next_url:
-            print("/GET {}".format(next_url))
+            print('/GET {}'.format(next_url))
             r = requests.get(next_url)
             r.raise_for_status()
             json_data = r.json()
-            for row in json_data["values"]:
-                for d in row["values"]:
+            for row in json_data['values']:
+                for d in row['values']:
                     yield Result(d['value'], {
                             'kpi': dataset.id,
                             'kpi_label': dataset.label,
@@ -102,7 +167,7 @@ class KoladaScraper(BaseScraper):
                     )
 
             #
-            if "next_page" in json_data:
-                next_url = json_data["next_page"]
+            if 'next_page' in json_data:
+                next_url = json_data['next_page']
             else:
                 next_url = False


### PR DESCRIPTION
Because of the previous `elif` you could only query by `municipality` or `period`, not both at the same time.

There were also a bug where it didn't get all towns from `allowed_values`. This commit adds support for regions and  municipality groups. So it detects if the dataset is for municipalities or regions and changes allowed municipality/municipality groups (both municipality and region in the same) accordingly